### PR TITLE
Fix broken Markdown headings

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,4 +56,4 @@ Currently this is only for Android (a.k.a. logcat)
 * Listen for all logs types (not just Titanium Exceptions)
 
 
-###Licence: MIT
+### Licence: MIT


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.
            
See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.
            
Tackles bryant1410/readmesfix#1